### PR TITLE
[PLATFORM-341]: [bridge_ex] - Retry customization

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.13.0-otp-24
+elixir 1.13.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.13.2
+elixir 1.13.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+### Added
+
+- New `retry_policy` option to `call`: clients can customize which errors are retried by providing a function
+
+### Changed
+
+- [**Breaking**] More detailed errors on bad response and http error: instead of returning a string, return an atom with some additional info
+
 ## [1.0.1] - 2022-03-07
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ This document describes the current status and the upcoming milestones of the `b
 | ❌ | [Support all possible outcomes of a GraphQL query](#support-all-possible-outcomes-of-a-graphql-query) | 💣 | - |
 | ❌ | [Log queries safely](#log-queries-safely) | - | - |
 | ❌ | [Use strings instead of atoms when deserializing GraphQL response](#use-strings-instead-of-atoms-when-deserializing-graphql-response) | 💣 | - |
-| ❌ | [Flexible retry policy](#make-retry-policy-more-flexible) | - | [341](https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-341) |
+| ✔ | [Flexible retry policy](#make-retry-policy-more-flexible) | 💣 | [341](https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-341) |
 | ❌ | [Exponential retry policy](#add-exponential-retry-policy) | - | [367](https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-367) |
 | ❌ | [Better renaming of `max_attempts`](#better-naming-of-max-attempts) | - | - |
 

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -72,6 +72,13 @@ defmodule BridgeEx.Graphql do
         * `headers`: extra HTTP headers.
         * `max_attempts`: override the configured `max_attempts` parameter.
 
+      ## Return values
+
+        * `{:ok, graphql_response}` on success
+        * `{:error, graphql_error}` on graphql error (i.e. 200 status code but `errors` array is not `nil`)
+        * `{:error, {:bad_response, status_code}}` on non 200 status code
+        * `{:error, {:http_error, reason}}` on http error e.g. `:econnrefused`
+
       ## Examples
 
         iex> MyBridge.call("some_query", %{var_key: "var_value"})

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -86,6 +86,7 @@ defmodule BridgeEx.Graphql do
         http_options = Keyword.merge(@http_options, Keyword.get(options, :options, []))
         http_headers = Map.merge(@http_headers, Keyword.get(options, :headers, %{}))
         max_attempts = Keyword.get(options, :max_attempts, @max_attempts)
+        retry_policy = Keyword.get(options, :retry_policy, fn _ -> true end)
 
         with {:ok, http_headers} <- with_authorization_headers(http_headers) do
           @endpoint
@@ -95,7 +96,8 @@ defmodule BridgeEx.Graphql do
             http_options,
             http_headers,
             max_attempts,
-            log_options()
+            log_options(),
+            retry_policy
           )
           |> format_response()
         end

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -5,7 +5,11 @@ defmodule BridgeEx.Graphql.Client do
 
   alias BridgeEx.Graphql.Utils
 
-  @type bridge_response :: {:ok, term()} | {:error, String.t()}
+  @type bridge_response ::
+          {:ok, term()}
+          | {:error, {:bad_response, integer()}}
+          | {:error, {:http_error, String.t()}}
+          | {:error, list()}
 
   @doc """
   Calls a GraphQL endpoint

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -28,7 +28,8 @@ defmodule BridgeEx.Graphql.Client do
           http_options :: Keyword.t(),
           http_headers :: map(),
           max_attempts :: integer(),
-          log_options :: Keyword.t()
+          log_options :: Keyword.t(),
+          retry_policy :: fun()
         ) :: bridge_response()
   def call(
         url,
@@ -38,7 +39,7 @@ defmodule BridgeEx.Graphql.Client do
         http_headers,
         max_attempts,
         log_options,
-        retry_fn \\ fn _ -> true end
+        retry_policy
       ) do
     %{query: String.trim(query), variables: variables}
     |> Jason.encode()
@@ -49,7 +50,7 @@ defmodule BridgeEx.Graphql.Client do
         |> Utils.decode_http_response(query, log_options)
         |> Utils.parse_response()
       end,
-      retry_fn,
+      retry_policy,
       max_attempts
     )
   end

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -37,7 +37,8 @@ defmodule BridgeEx.Graphql.Client do
         http_options,
         http_headers,
         max_attempts,
-        log_options
+        log_options,
+        retry_fn \\ fn _ -> true end
       ) do
     %{query: String.trim(query), variables: variables}
     |> Jason.encode()
@@ -48,6 +49,7 @@ defmodule BridgeEx.Graphql.Client do
         |> Utils.decode_http_response(query, log_options)
         |> Utils.parse_response()
       end,
+      retry_fn,
       max_attempts
     )
   end

--- a/mix.exs
+++ b/mix.exs
@@ -13,8 +13,16 @@ defmodule BridgeEx.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),
+      aliases: aliases(),
       package: package(),
       dialyzer: [plt_add_apps: [:prima_auth0_ex]]
+    ]
+  end
+
+  defp aliases do
+    [
+      "format.all":
+        "format mix.exs 'lib/**/*.{ex,exs}' 'test/**/*.{ex,exs}' 'config/*.{ex,exs}' 'priv/**/*.exs'"
     ]
   end
 

--- a/test/graphql_test.exs
+++ b/test/graphql_test.exs
@@ -34,7 +34,8 @@ defmodule BridgeEx.GraphqlTest do
       use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql", max_attempts: 2
     end
 
-    assert {:ok, %{key: "value"}} = TestBridgeWithRetry.call("myquery", %{})
+    assert {:ok, %{key: "value"}} =
+             TestBridgeWithRetry.call("myquery", %{})
   end
 
   test "retries request on response with errors", %{bypass: bypass} do

--- a/test/graphql_test.exs
+++ b/test/graphql_test.exs
@@ -34,8 +34,7 @@ defmodule BridgeEx.GraphqlTest do
       use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql", max_attempts: 2
     end
 
-    assert {:ok, %{key: "value"}} =
-             TestBridgeWithRetry.call("myquery", %{})
+    assert {:ok, %{key: "value"}} = TestBridgeWithRetry.call("myquery", %{})
   end
 
   test "retries request on response with errors", %{bypass: bypass} do


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-341

This PR introduces the ability to customize the retry policy in case of errors. Furthermore, errors are now returned in a more detailed way instead of just returning strings (this is potentially breaking, assuming someone depends on error being those particular strings).

