### PR TITLE
Align bridge_ex with improvements made on Peano

### DIFF
--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -71,6 +71,8 @@ defmodule BridgeEx.Graphql.Utils do
 
   @spec normalize_inner_fields(%{atom() => any()} | String.t()) :: %{atom() => any()} | String.t()
   def normalize_inner_fields(binary) when is_binary(binary), do: binary
+  def normalize_inner_fields(number) when is_number(number), do: number
+  def normalize_inner_fields(boolean) when is_boolean(boolean), do: boolean
   def normalize_inner_fields(map = %{}), do: Enum.reduce(map, %{}, &do_normalize_inner_fields/2)
   @spec do_normalize_inner_fields({atom(), any()}, map()) :: %{atom() => any()}
   defp do_normalize_inner_fields({key, value}, acc) when is_map(value) do

--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -69,12 +69,11 @@ defmodule BridgeEx.Graphql.Utils do
 
   def parse_response({:ok, %{data: data}}), do: {:ok, data}
 
-  @spec normalize_inner_fields(%{atom() => any()} | String.t()) :: %{atom() => any()} | String.t()
-  def normalize_inner_fields(binary) when is_binary(binary), do: binary
-  def normalize_inner_fields(number) when is_number(number), do: number
-  def normalize_inner_fields(boolean) when is_boolean(boolean), do: boolean
-  def normalize_inner_fields(map = %{}), do: Enum.reduce(map, %{}, &do_normalize_inner_fields/2)
-  @spec do_normalize_inner_fields({atom(), any()}, map()) :: %{atom() => any()}
+  @spec normalize_inner_fields(any()) :: any()
+  def normalize_inner_fields(map) when is_map(map),do: Enum.reduce(map, %{}, &do_normalize_inner_fields/2)
+  def normalize_inner_fields(value), do: value
+
+  @spec do_normalize_inner_fields({atom() | String.t(), any()}, map()) :: %{atom() => any()}
   defp do_normalize_inner_fields({key, value}, acc) when is_map(value) do
     Map.merge(acc, %{to_snake_case(key) => normalize_inner_fields(value)})
   end

--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -70,7 +70,9 @@ defmodule BridgeEx.Graphql.Utils do
   def parse_response({:ok, %{data: data}}), do: {:ok, data}
 
   @spec normalize_inner_fields(any()) :: any()
-  def normalize_inner_fields(map) when is_map(map),do: Enum.reduce(map, %{}, &do_normalize_inner_fields/2)
+  def normalize_inner_fields(map) when is_map(map),
+      do: Enum.reduce(map, %{}, &do_normalize_inner_fields/2)
+
   def normalize_inner_fields(value), do: value
 
   @spec do_normalize_inner_fields({atom() | String.t(), any()}, map()) :: %{atom() => any()}

--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -71,7 +71,7 @@ defmodule BridgeEx.Graphql.Utils do
 
   @spec normalize_inner_fields(any()) :: any()
   def normalize_inner_fields(map) when is_map(map),
-      do: Enum.reduce(map, %{}, &do_normalize_inner_fields/2)
+    do: Enum.reduce(map, %{}, &do_normalize_inner_fields/2)
 
   def normalize_inner_fields(value), do: value
 

--- a/test/graphql/utils_test.exs
+++ b/test/graphql/utils_test.exs
@@ -8,6 +8,14 @@ defmodule BridgeEx.Graphql.UtilsTest do
       assert "some-string" == Utils.normalize_inner_fields("some-string")
     end
 
+    test "does not change integers" do
+      assert 5 == Utils.normalize_inner_fields(5)
+    end
+
+    test "does not change booleans" do
+      assert true == Utils.normalize_inner_fields(true)
+    end
+
     test "does not change empty maps" do
       assert %{} == Utils.normalize_inner_fields(%{})
     end


### PR DESCRIPTION
this update allows the library to be in sync with the Peano version of `graphql_utils.ex`, so that it can be implemented there more easily in any use case.

More specifically, `normalize_inner_fields` now handle cases where the root value object is a number or a boolean. Before it would break at the following map pattern match