### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+## [1.1.0] - 2022-03-07
+
 ### Added
 
 - New `retry_options` to `call`: clients can customize how handle a call retry (more details [here](./README.md#customizing-the-retry-options))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New `retry_options` to `call`: clients can customize how handle a call retry (more details [here](./README.md#customizing-the-retry-options))
+- New `retry_options` to `call`: clients can customize how to handle a call retry (more details [here](./README.md#customizing-the-retry-options))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The package can be installed by adding `bridge_ex` to your list of dependencies 
 ```elixir
 def deps do
   [
-    {:bridge_ex, "~> 1.0.0"}
+    {:bridge_ex, "~> 1.1.0"}
     # only if you want auth0 too
     # {:prima_auth0_ex, "~> 0.3.0"}
   ]

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BridgeEx.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/bridge_ex"
-  @version "1.0.1"
+  @version "1.1.0"
 
   def project do
     [


### PR DESCRIPTION
Since there are a few upgrades I thought we could release a new version. This release contains a potentially breaking change (i.e. different error return format) but AFAIK no one depends on the error being a string, so...