### PR TITLE
[PLATFORM-451]: [Bridge_Ex] Refactor encode_variables option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+### Fixed
+
+- `BridgeEx.Graphql.Client.call` accepts only `variables :: map()` once again
+- `BridgeEx.Graphql.Client.call` now performs `variables` encoding internally
+
 ## [1.2.0] - 2022-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+## [2.0.0] - 2022-05-19
+
+### Changed
+
+- **Breaking**: `BridgeEx.Graphql.Client.call` now accepts an `opts :: Keyword.t()` parameter instead of specific options
+
 ### Fixed
 
 - `BridgeEx.Graphql.Client.call` accepts only `variables :: map()` once again
@@ -104,7 +110,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation of `bridge_ex`
 
-[Next]: https://github.com/primait/bridge_ex/compare/1.1.0...HEAD
+[Next]: https://github.com/primait/bridge_ex/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/primait/bridge_ex/compare/1.2.0...2.0.0
+[1.2.0]: https://github.com/primait/bridge_ex/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/primait/bridge_ex/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/primait/bridge_ex/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/primait/bridge_ex/compare/0.4.1...1.0.0

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The package can be installed by adding `bridge_ex` to your list of dependencies 
 ```elixir
 def deps do
   [
-    {:bridge_ex, "~> 1.2.0"}
+    {:bridge_ex, "~> 2.0.0"}
     # only if you want auth0 too
     # {:prima_auth0_ex, "~> 0.3.0"}
   ]

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -91,14 +91,13 @@ defmodule BridgeEx.Graphql do
       @spec call(
               query :: String.t(),
               variables :: map(),
-              options :: Keyword.t()
+              opts :: Keyword.t()
             ) :: Client.bridge_response()
-      def call(query, variables, options \\ []) do
-        http_options = Keyword.merge(@http_options, Keyword.get(options, :options, []))
-        http_headers = Map.merge(@http_headers, Keyword.get(options, :headers, %{}))
-        max_attempts = Keyword.get(options, :max_attempts, @max_attempts)
-
-        user_retry_options = Keyword.get(options, :retry_options, [])
+      def call(query, variables, opts \\ []) do
+        http_options = Keyword.merge(@http_options, Keyword.get(opts, :options, []))
+        http_headers = Map.merge(@http_headers, Keyword.get(opts, :headers, %{}))
+        max_attempts = Keyword.get(opts, :max_attempts, @max_attempts)
+        user_retry_options = Keyword.get(opts, :retry_options, [])
 
         retry_options =
           Keyword.merge(
@@ -116,11 +115,11 @@ defmodule BridgeEx.Graphql do
           |> Client.call(
             query,
             variables,
-            @encode_variables,
-            http_options,
-            http_headers,
-            retry_options,
-            log_options()
+            encode_variables: @encode_variables,
+            http_options: http_options,
+            http_headers: http_headers,
+            log_options: log_options(),
+            retry_options: retry_options
           )
           |> format_response()
         end

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -51,6 +51,7 @@ defmodule BridgeEx.Graphql do
       # optional opts with defaults
       @auth0_enabled get_in(unquote(opts), [:auth0, :enabled]) || false
       @audience get_in(unquote(opts), [:auth0, :audience])
+      @encode_variables Keyword.get(unquote(opts), :encode_variables, false)
       @http_options Keyword.get(unquote(opts), :http_options, timeout: 1_000, recv_timeout: 16_000)
       @http_headers Keyword.get(unquote(opts), :http_headers, %{
                       "Content-type" => "application/json"
@@ -114,7 +115,8 @@ defmodule BridgeEx.Graphql do
           @endpoint
           |> Client.call(
             query,
-            encode_variables(variables),
+            variables,
+            @encode_variables,
             http_options,
             http_headers,
             retry_options,
@@ -122,13 +124,6 @@ defmodule BridgeEx.Graphql do
           )
           |> format_response()
         end
-      end
-
-      # define helpers at compile-time, to avoid dialyzer errors about pattern matching constants
-      if Keyword.get(unquote(opts), :encode_variables, false) do
-        defp encode_variables(variables), do: Jason.encode!(variables)
-      else
-        defp encode_variables(variables), do: variables
       end
 
       if Keyword.get(unquote(opts), :format_response, false) do

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -20,6 +20,10 @@ defmodule BridgeEx.Graphql.Client do
     * `url`: URL of the endpoint.
     * `query`: Graphql query or mutation.
     * `variables`: variables for Graphql query or mutation.
+    * `opts`: various options.
+
+  ## Options
+
     * `encode_variables`: whether to encode variables or not.
     * `http_options`: HTTPoison options.
     * `http_headers`: HTTPoison headers.
@@ -31,23 +35,20 @@ defmodule BridgeEx.Graphql.Client do
           url :: String.t(),
           query :: String.t(),
           variables :: map(),
-          encode_variables :: boolean(),
-          http_options :: Keyword.t(),
-          http_headers :: map(),
-          retry_options :: Keyword.t(),
-          log_options :: Keyword.t()
+          opts :: Keyword.t()
         ) :: bridge_response()
   def call(
         url,
         query,
         variables,
-        encode_variables,
-        http_options,
-        http_headers,
-        retry_options,
-        log_options
+        opts
       ) do
-    # define helpers at compile-time, to avoid dialyzer errors about pattern matching constants
+    encode_variables = Keyword.get(opts, :encode_variables)
+    http_options = Keyword.get(opts, :http_options)
+    http_headers = Keyword.get(opts, :http_headers)
+    log_options = Keyword.get(opts, :log_options)
+    retry_options = Keyword.get(opts, :retry_options)
+
     variables =
       if encode_variables,
         do: Jason.encode!(variables),

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -19,7 +19,8 @@ defmodule BridgeEx.Graphql.Client do
 
     * `url`: URL of the endpoint.
     * `query`: Graphql query or mutation.
-    * `variables`: dariables for Graphql query or mutation.
+    * `variables`: variables for Graphql query or mutation.
+    * `encode_variables`: whether to encode variables or not.
     * `http_options`: HTTPoison options.
     * `http_headers`: HTTPoison headers.
     * `retry_options`: configures retry attempts. Takes the form of `[max_retries: 1, timing: :exponential]`
@@ -29,7 +30,8 @@ defmodule BridgeEx.Graphql.Client do
   @spec call(
           url :: String.t(),
           query :: String.t(),
-          variables :: map() | String.t(),
+          variables :: map(),
+          encode_variables :: boolean(),
           http_options :: Keyword.t(),
           http_headers :: map(),
           retry_options :: Keyword.t(),
@@ -39,11 +41,18 @@ defmodule BridgeEx.Graphql.Client do
         url,
         query,
         variables,
+        encode_variables,
         http_options,
         http_headers,
         retry_options,
         log_options
       ) do
+    # define helpers at compile-time, to avoid dialyzer errors about pattern matching constants
+    variables =
+      if encode_variables,
+        do: Jason.encode!(variables),
+        else: variables
+
     %{query: String.trim(query), variables: variables}
     |> Jason.encode()
     |> Noether.Either.bind(

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BridgeEx.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/bridge_ex"
-  @version "1.2.0"
+  @version "2.0.0"
 
   def project do
     [


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-451

This PR attempts to refactor the internal client's `call` method to restrict the type of `variables` to `map` once again

