### PR TITLE
Deprecate decoding using atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Bridges to Graphql services are defined by `use`ing the `BridgeEx.Graphql` macro
 
 ```elixir
 defmodule MyApp.SomeServiceBridge do
-  use BridgeEx.Graphql, endpoint: "http://some_service.example.com", decoder: :strings
+  use BridgeEx.Graphql, endpoint: "http://some_service.example.com", decode_keys: :strings
 
   def my_query(%{} = variables) do
     call("a graphql query or mutation", variables, retry_policy: [max_retries: 1])
@@ -25,7 +25,7 @@ defmodule MyApp.SomeServiceBridge do
 end
 ```
 
-Besides `endpoint` and `decoder`, the following parameters can be optionally set when `use`ing `BridgeEx.Graphql`:
+Besides `endpoint` and `decode_keys`, the following parameters can be optionally set when `use`ing `BridgeEx.Graphql`:
 
 - `auth0`
 - `encode_variables`
@@ -36,7 +36,7 @@ Besides `endpoint` and `decoder`, the following parameters can be optionally set
 - `log_options`
 - `max_attempts` `⚠ Deprecated in favour of retry_options in call method`
 
-The option `decoder` determines how JSON keys are decoded. By default it is set to `:atoms` which is the previous behavior and is deprecated since it may raise security concerns. See ["Decoding keys to atoms" in Jason documentation](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) for more information. Other options include `:strings` and `:existing_atoms` which are safer, but a custom function can also be used. In the future, `:strings` decoder will be used by default.
+The option `decode_keys` determines how JSON keys are decoded. By default it is set to `:atoms` which is the previous behavior and is deprecated since it may raise security concerns. See ["Decoding keys to atoms" in Jason documentation](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) for more information. Other options include `:strings` and `:existing_atoms` which are safer. In the future, `:strings` keys decoder will be used by default.
 
 Refer to [the documentation](https://hexdocs.pm/bridge_ex/BridgeEx.Graphql.html) for more details.
 
@@ -46,7 +46,7 @@ The library supports preloading queries from external files via the `BridgeEx.Ex
 
 ```elixir
 defmodule MyApp.SomeServiceBridge do
-  use BridgeEx.Graphql, endpoint: "http://some_service.example.com", decoder: :strings
+  use BridgeEx.Graphql, endpoint: "http://some_service.example.com", decode_keys: :strings
   use BridgeEx.Extensions.ExternalResources, resources: [my_query: "my_query.graphql"]
 
   def my_query(%{} = variables), do: call(my_query(), variables)
@@ -96,7 +96,7 @@ end
 
 defmodule BridgeWithCustomRetry do
   use BridgeEx.Graphql,
-    endpoint: "http://some_service.example.com/graphql", decoder: :strings
+    endpoint: "http://some_service.example.com/graphql", decode_keys: :strings
 end
 
 BridgeWithCustomRetry.call("myquery", %{}, retry_options: [policy: retry_policy, max_retries: 2])
@@ -124,7 +124,7 @@ Then configure your bridge with the audience of the target service:
 ```elixir
 use BridgeEx.Graphql,
   endpoint: "...",
-  decoder: :strings,
+  decode_keys: :strings,
   auth0: [enabled: true, audience: "target_audience"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Besides `endpoint` and `decode_keys`, the following parameters can be optionally
 - `log_options`
 - `max_attempts` `⚠ Deprecated in favour of retry_options in call method`
 
-The option `decode_keys` determines how JSON keys are decoded. By default it is set to `:atoms` which is the previous behavior and is deprecated since it may raise security concerns. See ["Decoding keys to atoms" in Jason documentation](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) for more information. Other options include `:strings` and `:existing_atoms` which are safer. In the future, `:strings` keys decoder will be used by default.
+The option `decode_keys` determines how JSON keys in GraphQL responses are decoded. If you don't provide it, it is set by default to `:atoms`, which is **highly discouraged** since it may raise security concerns (see ["Decoding keys to atoms" in Jason documentation](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) for more information). Other decoding modes are `:strings` and `:existing_atoms` which are safer. In a future version, this option will be set by default to `:strings`.
 
 Refer to [the documentation](https://hexdocs.pm/bridge_ex/BridgeEx.Graphql.html) for more details.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Besides `endpoint` and `decoder`, the following parameters can be optionally set
 - `log_options`
 - `max_attempts` `⚠ Deprecated in favour of retry_options in call method`
 
-The option `decoder` determines how JSON keys are decoded. By default it is set to `:atoms` which is the previous behavior and is deprecated since it may raise security concerns. See ["Decoding keys to atoms" in Jason documentation](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) for more information. In the future, a basic string decoder will be used.
+The option `decoder` determines how JSON keys are decoded. By default it is set to `:atoms` which is the previous behavior and is deprecated since it may raise security concerns. See ["Decoding keys to atoms" in Jason documentation](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) for more information. Other options include `:strings` and `:existing_atoms` which are safer, but a custom function can also be used. In the future, `:strings` decoder will be used by default.
 
 Refer to [the documentation](https://hexdocs.pm/bridge_ex/BridgeEx.Graphql.html) for more details.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Bridges to Graphql services are defined by `use`ing the `BridgeEx.Graphql` macro
 
 ```elixir
 defmodule MyApp.SomeServiceBridge do
-  use BridgeEx.Graphql, endpoint: "http://some_service.example.com"
+  use BridgeEx.Graphql, endpoint: "http://some_service.example.com", decoder: :strings
 
   def my_query(%{} = variables) do
     call("a graphql query or mutation", variables, retry_policy: [max_retries: 1])
@@ -25,7 +25,7 @@ defmodule MyApp.SomeServiceBridge do
 end
 ```
 
-Besides `endpoint`, the following parameters can be optionally set when `use`ing `BridgeEx.Graphql`:
+Besides `endpoint` and `decoder`, the following parameters can be optionally set when `use`ing `BridgeEx.Graphql`:
 
 - `auth0`
 - `encode_variables`
@@ -36,6 +36,8 @@ Besides `endpoint`, the following parameters can be optionally set when `use`ing
 - `log_options`
 - `max_attempts` `⚠ Deprecated in favour of retry_options in call method`
 
+The option `decoder` determines how JSON keys are decoded. By default it is set to `:atoms` which is the previous behavior and is deprecated since it may raise security concerns. See ["Decoding keys to atoms" in Jason documentation](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) for more information. In the future, a basic string decoder will be used.
+
 Refer to [the documentation](https://hexdocs.pm/bridge_ex/BridgeEx.Graphql.html) for more details.
 
 If you need more control on your requests you can use [`BridgeEx.Graphql.Client.call`](https://hexdocs.pm/bridge_ex/BridgeEx.Graphql.Client.html#call/7) directly.
@@ -44,7 +46,7 @@ The library supports preloading queries from external files via the `BridgeEx.Ex
 
 ```elixir
 defmodule MyApp.SomeServiceBridge do
-  use BridgeEx.Graphql, endpoint: "http://some_service.example.com"
+  use BridgeEx.Graphql, endpoint: "http://some_service.example.com", decoder: :strings
   use BridgeEx.Extensions.ExternalResources, resources: [my_query: "my_query.graphql"]
 
   def my_query(%{} = variables), do: call(my_query(), variables)
@@ -94,7 +96,7 @@ end
 
 defmodule BridgeWithCustomRetry do
   use BridgeEx.Graphql,
-    endpoint: "http://some_service.example.com/graphql"
+    endpoint: "http://some_service.example.com/graphql", decoder: :strings
 end
 
 BridgeWithCustomRetry.call("myquery", %{}, retry_options: [policy: retry_policy, max_retries: 2])
@@ -122,6 +124,7 @@ Then configure your bridge with the audience of the target service:
 ```elixir
 use BridgeEx.Graphql,
   endpoint: "...",
+  decoder: :strings,
   auth0: [enabled: true, audience: "target_audience"]
 ```
 

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -60,7 +60,7 @@ defmodule BridgeEx.Graphql do
       @max_attempts Keyword.get(unquote(opts), :max_attempts, 1)
       @log_options Keyword.get(unquote(opts), :log_options, [])
       @format_variables Keyword.get(unquote(opts), :format_variables, false)
-      @decoder Keyword.get(unquote(opts), :decoder, :atoms)
+      @decode_keys Keyword.get(unquote(opts), :decode_keys, :atoms)
 
       if Keyword.has_key?(unquote(opts), :max_attempts) do
         IO.warn(
@@ -69,9 +69,9 @@ defmodule BridgeEx.Graphql do
         )
       end
 
-      if !Keyword.has_key?(unquote(opts), :decoder) do
+      if !Keyword.has_key?(unquote(opts), :decode_keys) do
         IO.warn(
-          "missing decoder option in graphql bridge creation. Currently fallbacks to the discouraged atom decoder which may lead to memory leak and raise security concerns. It will be replaced by a safer string decoder in a future major release. If you want to keep the current behavior and hide this warning, just add `decoder: :atoms` to your bridge creation options.",
+          "missing decode_keys option in graphql bridge creation. Currently fallbacks to the discouraged atom keys decoder which may lead to memory leak and raise security concerns. It will be replaced with the safer :strings keys decoder in a future major release. If you want to keep the current behavior and hide this warning, just add `decode_keys: :atoms` to your bridge creation options.",
           Macro.Env.stacktrace(__ENV__)
         )
       end
@@ -118,13 +118,13 @@ defmodule BridgeEx.Graphql do
           |> Client.call(
             query,
             variables,
-            @decoder,
             options: http_options,
             headers: http_headers,
             encode_variables: @encode_variables,
             log_options: @log_options,
             retry_options: retry_options,
-            format_variables: @format_variables
+            format_variables: @format_variables,
+            decode_keys: @decode_keys
           )
           |> format_response()
         end

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -15,7 +15,7 @@ defmodule BridgeEx.Graphql do
     * `http_options`: HTTP options to be passed to Telepoison. Defaults to `[timeout: 1_000, recv_timeout: 16_000]`.
     * `log_options`: override global configuration for logging errors. Takes the form of `[log_query_on_error: false, log_response_on_error: false]`
     * `max_attempts`: number of times the request will be retried upon failure. Defaults to `1`. ⚠️ Deprecated: use retry_options instead.
-    * `decode_keys`: selects which key decoder to use for decoding responses: `:atoms`, `:strings`, `:existing_atoms` . Defaults to `atoms` which is deprecated and will be replaced by `strings` in a future version of this lib.
+    * `decode_keys`: determines how JSON keys in GraphQL responses are decoded. Can be set to `:atoms`, `:strings` or `:existing_atoms`. Currently, the default mode is `:atoms` but will be changed to `:strings` in a future version of this library. You are highly encouraged to set this option to `:strings` to avoid [memory leaks and security concerns](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms).
     * `retry_options`: override configuration regarding retries, namely
       * `delay`: meaning depends on `timing`
         * `:constant`: retry ever `delay` ms
@@ -71,7 +71,7 @@ defmodule BridgeEx.Graphql do
 
       unless Keyword.has_key?(unquote(opts), :decode_keys) do
         IO.warn(
-          "missing decode_keys option in graphql bridge creation. Currently fallbacks to the discouraged atom keys decoder which may lead to memory leak and raise security concerns. It will be replaced with the safer :strings keys decoder in a future major release. If you want to keep the current behavior and hide this warning, just add `decode_keys: :atoms` to your bridge creation options.",
+          "missing decode_keys option for this GraphQL bridge. Currently fallbacks to :atoms which may lead to memory leaks and raise security concerns. If you want to keep the current behavior and hide this warning, just add `decode_keys: :atoms` to the options of this bridge. You should however consider migrating to `decode_keys: :strings`.",
           Macro.Env.stacktrace(__ENV__)
         )
       end

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -69,7 +69,7 @@ defmodule BridgeEx.Graphql do
         )
       end
 
-      if !Keyword.has_key?(unquote(opts), :decode_keys) do
+      unless Keyword.has_key?(unquote(opts), :decode_keys) do
         IO.warn(
           "missing decode_keys option in graphql bridge creation. Currently fallbacks to the discouraged atom keys decoder which may lead to memory leak and raise security concerns. It will be replaced with the safer :strings keys decoder in a future major release. If you want to keep the current behavior and hide this warning, just add `decode_keys: :atoms` to your bridge creation options.",
           Macro.Env.stacktrace(__ENV__)

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -15,7 +15,7 @@ defmodule BridgeEx.Graphql do
     * `http_options`: HTTP options to be passed to Telepoison. Defaults to `[timeout: 1_000, recv_timeout: 16_000]`.
     * `log_options`: override global configuration for logging errors. Takes the form of `[log_query_on_error: false, log_response_on_error: false]`
     * `max_attempts`: number of times the request will be retried upon failure. Defaults to `1`. ⚠️ Deprecated: use retry_options instead.
-    * `decoder`: selects which decoder to use for decoding responses. In order to decode JSON files, it's possible to use one of the three basic strategies (`:atoms`, `:existing_atoms`, `:strings`), but it's also possible to implement a custom decoder as a function which takes a body as parameter and returns a `{:ok, any}` or `{:error, any}` tuple. Defaults to `atoms` which is deprecated and will be replaced by `strings` in a future version of this lib.
+    * `decode_keys`: selects which key decoder to use for decoding responses: `:atoms`, `:strings`, `:existing_atoms` . Defaults to `atoms` which is deprecated and will be replaced by `strings` in a future version of this lib.
     * `retry_options`: override configuration regarding retries, namely
       * `delay`: meaning depends on `timing`
         * `:constant`: retry ever `delay` ms

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -15,7 +15,7 @@ defmodule BridgeEx.Graphql do
     * `http_options`: HTTP options to be passed to Telepoison. Defaults to `[timeout: 1_000, recv_timeout: 16_000]`.
     * `log_options`: override global configuration for logging errors. Takes the form of `[log_query_on_error: false, log_response_on_error: false]`
     * `max_attempts`: number of times the request will be retried upon failure. Defaults to `1`. ⚠️ Deprecated: use retry_options instead.
-    * `decoder`: selects which decoder to use for decoding responses. Defaults to atom_decoder which is deprecated and will be replaced by string_decoder.
+    * `decoder`: selects which decoder to use for decoding responses. In order to decode JSON files, it's possible to use one of the three basic strategies (`:atoms`, `:existing_atoms`, `:strings`), but it's also possible to implement a custom decoder as a function which takes a body as parameter and returns a `{:ok, any}` or `{:error, any}` tuple. Defaults to `atoms` which is deprecated and will be replaced by `strings` in a future version of this lib.
     * `retry_options`: override configuration regarding retries, namely
       * `delay`: meaning depends on `timing`
         * `:constant`: retry ever `delay` ms
@@ -60,7 +60,7 @@ defmodule BridgeEx.Graphql do
       @max_attempts Keyword.get(unquote(opts), :max_attempts, 1)
       @log_options Keyword.get(unquote(opts), :log_options, [])
       @format_variables Keyword.get(unquote(opts), :format_variables, false)
-      @decoder Keyword.get(unquote(opts), :decoder, &Utils.atom_decoder/1)
+      @decoder Keyword.get(unquote(opts), :decoder, :atoms)
 
       if Keyword.has_key?(unquote(opts), :max_attempts) do
         IO.warn(
@@ -71,7 +71,7 @@ defmodule BridgeEx.Graphql do
 
       if !Keyword.has_key?(unquote(opts), :decoder) do
         IO.warn(
-          "missing decoder option in graphql bridge creation. Currently fallbacks to the discouraged atom decoder which may lead to memory leak and raise security concerns. It will be replaced by a safer string decoder in a future major release",
+          "missing decoder option in graphql bridge creation. Currently fallbacks to the discouraged atom decoder which may lead to memory leak and raise security concerns. It will be replaced by a safer string decoder in a future major release. If you want to keep the current behavior and hide this warning, just add `decoder: :atoms` to your bridge creation options.",
           Macro.Env.stacktrace(__ENV__)
         )
       end

--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -10,11 +10,11 @@ defmodule BridgeEx.Graphql do
     * `auth0`: enable and configure Auth0 for authentication of requests. Takes the form of `[enabled: false, audience: "target-audience"]`.
     * `encode_variables`: if true, encode the Graphql variables to JSON. Defaults to `false`.
     * `format_response`: transforms camelCase keys in response to snake_case. Defaults to `false`.
-    * `format_variables`: transforms snake_case variable names to camelCase`. Defaults to `false`.
-    * `http_headers`: HTTP headers for the request. Defaults to `%{"Content-type": "application/json"}`
+    * `format_variables`: transforms snake_case variable names to camelCase. Defaults to `false`.
+    * `http_headers`: HTTP headers for the request. Defaults to `%{"Content-type": "application/json"}`.
     * `http_options`: HTTP options to be passed to Telepoison. Defaults to `[timeout: 1_000, recv_timeout: 16_000]`.
-    * `log_options`: override global configuration for logging errors. Takes the form of `[log_query_on_error: false, log_response_on_error: false]`
-    * `max_attempts`: number of times the request will be retried upon failure. Defaults to `1`. ⚠️ Deprecated: use retry_options instead.
+    * `log_options`: override global configuration for logging errors. Takes the form of `[log_query_on_error: false, log_response_on_error: false]`.
+    * `max_attempts`: number of times the request will be retried upon failure. Defaults to `1`. ⚠️ Deprecated: use `retry_options` instead.
     * `decode_keys`: determines how JSON keys in GraphQL responses are decoded. Can be set to `:atoms`, `:strings` or `:existing_atoms`. Currently, the default mode is `:atoms` but will be changed to `:strings` in a future version of this library. You are highly encouraged to set this option to `:strings` to avoid [memory leaks and security concerns](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms).
     * `retry_options`: override configuration regarding retries, namely
       * `delay`: meaning depends on `timing`

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -75,7 +75,7 @@ defmodule BridgeEx.Graphql.Client do
           opts :: Keyword.t()
         ) :: bridge_response()
   def call(url, query, variables, keys_decoder, opts) when is_atom(keys_decoder),
-    do: call(url, query, variables, Utils.json_decoder(keys_decoder), opts)
+    do: call(url, query, variables, json_decoder(keys_decoder), opts)
 
   def call(
         url,
@@ -148,4 +148,9 @@ defmodule BridgeEx.Graphql.Client do
   @spec do_encode_variables(any(), bool()) :: any()
   defp do_encode_variables(variables, true), do: Jason.encode!(variables)
   defp do_encode_variables(variables, false), do: variables
+
+  @spec json_decoder(atom()) :: (String.t() -> bridge_response())
+  defp json_decoder(:atoms), do: &Jason.decode(&1, keys: :atoms)
+  defp json_decoder(:existing_atoms), do: &Jason.decode(&1, keys: :atoms!)
+  defp json_decoder(:strings), do: &Jason.decode(&1)
 end

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -71,11 +71,11 @@ defmodule BridgeEx.Graphql.Client do
           url :: String.t(),
           query :: String.t(),
           variables :: map(),
-          keys_decoder :: (String.t() -> bridge_response()) | atom(),
+          decoder :: (String.t() -> bridge_response()) | atom(),
           opts :: Keyword.t()
         ) :: bridge_response()
-  def call(url, query, variables, keys_decoder, opts) when is_atom(keys_decoder),
-    do: call(url, query, variables, json_decoder(keys_decoder), opts)
+  def call(url, query, variables, decoder, opts) when is_atom(decoder),
+    do: call(url, query, variables, json_decoder(decoder), opts)
 
   def call(
         url,

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -35,7 +35,7 @@ defmodule BridgeEx.Graphql.Client do
     * `options`: extra HTTP options to be passed to Telepoison.
     * `headers`: extra HTTP headers.
     * `encode_variables`: whether to JSON encode variables or not.
-    * `decode_keys`: how JSON keys are decoded. Valid options are :strings (recommended), :atoms (currently the default, but discouraged due to security concerns - will be changed to :strings in a future version), :existing_atoms (safest, but may crash the application if an unexpected key is received)
+    * `decode_keys`: how JSON keys in GraphQL responses are decoded. Can be set to `:strings` (recommended), `:atoms` (discouraged due to [security concerns](https://hexdocs.pm/jason/Jason.html#decode/2-decoding-keys-to-atoms) - currently the default, but will be changed to :strings in a future version) or `:existing_atoms` (safer, but may crash the application if an unexpected key is received)
     * `retry_options`: configures retry attempts. Takes the form of `[max_retries: 1, timing: :exponential]`
     * `log_options`: configures logging on errors. Takes the form of `[log_query_on_error: false, log_response_on_error: false]`.
   """
@@ -61,7 +61,7 @@ defmodule BridgeEx.Graphql.Client do
     unless Keyword.has_key?(opts, :decode_keys),
       do:
         Logger.warning(
-          "BridgeEx.Client.call will decode keys using atoms. This is discouraged and will be changed in a future version. To silence this warning, pass decode_keys: :atoms to the call function."
+          "BridgeEx.Client.call will decode keys using atoms. This is discouraged and will be changed in a future version. To silence this warning, pass `decode_keys: :atoms` to this function or migrate to the safer `decode_keys: :strings` option."
         )
 
     retry_options =

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -38,7 +38,7 @@ defmodule BridgeEx.Graphql.Client do
     * `retry_options`: configures retry attempts. Takes the form of `[max_retries: 1, timing: :exponential]`
     * `log_options`: configures logging on errors. Takes the form of `[log_query_on_error: false, log_response_on_error: false]`.
   """
-  @deprecated "This call uses `Json.decode` with `keys: :atoms` which is discouraged as it dynamically creates atoms which are not garbage collected. Please use `call/5` with a decoder instead. For instance, you can use `Client.call(url, query, variables, &Utils.string_decoder/1, opts)` which will be the default behavior in the future."
+  @deprecated "This call uses `Json.decode` with `keys: :atoms` which is discouraged as it dynamically creates atoms which are not garbage collected. Please use `call/5` with a decoder instead. For instance, you can use `Client.call(url, query, variables, :strings, opts)` which will be the default behavior in the future."
   @spec call(
           url :: String.t(),
           query :: String.t(),

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -56,7 +56,7 @@ defmodule BridgeEx.Graphql.Client do
     * `url`: URL of the endpoint.
     * `query`: Graphql query or mutation.
     * `variables`: variables for Graphql query or mutation.
-    * `decoder`: decoder for the response. Can be an atom (:strings, :atoms, :existing_atoms) for JSON parsing or a function which transforms a body into a {:ok, any} or {:error, any} tuple. Some basic decoders are provided in the `BridgeEx.Graphql.Utils` module.
+    * `decoder`: decoder for the response. Can be an atom (:strings, :atoms, :existing_atoms) for JSON parsing or a function which transforms a body into a {:ok, any} or {:error, any} tuple.
     * `opts`: various options.
 
   ## Options

--- a/lib/graphql/client.ex
+++ b/lib/graphql/client.ex
@@ -46,7 +46,7 @@ defmodule BridgeEx.Graphql.Client do
           opts :: Keyword.t()
         ) :: bridge_response()
   def call(url, query, variables, opts),
-    do: call(url, query, variables, &Utils.atom_decoder/1, opts)
+    do: call(url, query, variables, :atoms, opts)
 
   @doc """
   Calls a GraphQL endpoint and decodes the response
@@ -56,7 +56,7 @@ defmodule BridgeEx.Graphql.Client do
     * `url`: URL of the endpoint.
     * `query`: Graphql query or mutation.
     * `variables`: variables for Graphql query or mutation.
-    * `decoder`: decoder for the response. Takes the form of `(String.t() -> client_response())`, several decoders are provided in the `BridgeEx.Graphql.Utils` module.
+    * `decoder`: decoder for the response. Can be an atom (:strings, :atoms, :existing_atoms) for JSON parsing or a function which transforms a body into a {:ok, any} or {:error, any} tuple. Some basic decoders are provided in the `BridgeEx.Graphql.Utils` module.
     * `opts`: various options.
 
   ## Options
@@ -71,9 +71,12 @@ defmodule BridgeEx.Graphql.Client do
           url :: String.t(),
           query :: String.t(),
           variables :: map(),
-          decoder :: (String.t() -> bridge_response()),
+          keys_decoder :: (String.t() -> bridge_response()) | atom(),
           opts :: Keyword.t()
         ) :: bridge_response()
+  def call(url, query, variables, keys_decoder, opts) when is_atom(keys_decoder),
+    do: call(url, query, variables, Utils.json_decoder(keys_decoder), opts)
+
   def call(
         url,
         query,

--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -24,17 +24,16 @@ defmodule BridgeEx.Graphql.Utils do
           {:ok, HTTPoison.Response.t() | HTTPoison.AsyncResponse.t()}
           | {:error, HTTPoison.Error.t()},
           String.t(),
-          (String.t() -> client_response()),
+          :strings | :atoms | :existing_atoms,
           Keyword.t()
         ) :: client_response()
   def decode_http_response(
         {:ok, %HTTPoison.Response{status_code: 200, body: body_string}},
         _,
-        decoder,
+        decode_keys,
         _
-      ) do
-    decoder.(body_string)
-  end
+      ),
+      do: decode_json(body_string, decode_keys)
 
   def decode_http_response(
         {:ok,
@@ -80,4 +79,10 @@ defmodule BridgeEx.Graphql.Utils do
 
   defp prepend_if(list, false, _), do: list
   defp prepend_if(list, true, value), do: [value | list]
+
+  @spec decode_json(String.t(), :strings | :atoms | :existing_atoms) ::
+          {:ok, map()} | {:error, any()}
+  defp decode_json(body, :strings), do: Jason.decode(body)
+  defp decode_json(body, :atoms), do: Jason.decode(body, keys: :atoms)
+  defp decode_json(body, :existing_atoms), do: Jason.decode(body, keys: :atoms!)
 end

--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -82,6 +82,10 @@ defmodule BridgeEx.Graphql.Utils do
   def existing_atom_decoder(body), do: Jason.decode(body, keys: :atoms!)
   def string_decoder(body), do: Jason.decode(body)
 
+  def json_decoder(:atoms), do: &atom_decoder/1
+  def json_decoder(:existing_atoms), do: &existing_atom_decoder/1
+  def json_decoder(:strings), do: &string_decoder/1
+
   defp prepend_if(list, false, _), do: list
   defp prepend_if(list, true, value), do: [value | list]
 end

--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -78,10 +78,6 @@ defmodule BridgeEx.Graphql.Utils do
   def parse_response({:ok, %{data: data}}), do: {:ok, data}
   def parse_response({:ok, %{"data" => data}}), do: {:ok, data}
 
-  def json_decoder(:atoms), do: &Jason.decode(&1, keys: :atoms)
-  def json_decoder(:existing_atoms), do: &Jason.decode(&1, keys: :atoms!)
-  def json_decoder(:strings), do: &Jason.decode(&1)
-
   defp prepend_if(list, false, _), do: list
   defp prepend_if(list, true, value), do: [value | list]
 end

--- a/lib/graphql/utils.ex
+++ b/lib/graphql/utils.ex
@@ -78,13 +78,9 @@ defmodule BridgeEx.Graphql.Utils do
   def parse_response({:ok, %{data: data}}), do: {:ok, data}
   def parse_response({:ok, %{"data" => data}}), do: {:ok, data}
 
-  def atom_decoder(body), do: Jason.decode(body, keys: :atoms)
-  def existing_atom_decoder(body), do: Jason.decode(body, keys: :atoms!)
-  def string_decoder(body), do: Jason.decode(body)
-
-  def json_decoder(:atoms), do: &atom_decoder/1
-  def json_decoder(:existing_atoms), do: &existing_atom_decoder/1
-  def json_decoder(:strings), do: &string_decoder/1
+  def json_decoder(:atoms), do: &Jason.decode(&1, keys: :atoms)
+  def json_decoder(:existing_atoms), do: &Jason.decode(&1, keys: :atoms!)
+  def json_decoder(:strings), do: &Jason.decode(&1)
 
   defp prepend_if(list, false, _), do: list
   defp prepend_if(list, true, value), do: [value | list]

--- a/test/auth0_authentication_test.exs
+++ b/test/auth0_authentication_test.exs
@@ -30,7 +30,7 @@ defmodule BridgeEx.Auth0AuthenticationTest do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
         auth0: [audience: "my-audience", enabled: true],
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     assert {:ok, %{key: "value"}} = TestBridgeWithAuth0.call("myquery", %{})
@@ -48,7 +48,7 @@ defmodule BridgeEx.Auth0AuthenticationTest do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
         auth0: [audience: "my-audience", enabled: true],
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     catch_exit(TestBridgeWithAuth0EnabledOnlyInBridge.call("myquery", %{}))

--- a/test/auth0_authentication_test.exs
+++ b/test/auth0_authentication_test.exs
@@ -29,7 +29,8 @@ defmodule BridgeEx.Auth0AuthenticationTest do
     defmodule TestBridgeWithAuth0 do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        auth0: [audience: "my-audience", enabled: true]
+        auth0: [audience: "my-audience", enabled: true],
+        decoder: :atoms
     end
 
     assert {:ok, %{key: "value"}} = TestBridgeWithAuth0.call("myquery", %{})
@@ -46,7 +47,8 @@ defmodule BridgeEx.Auth0AuthenticationTest do
     defmodule TestBridgeWithAuth0EnabledOnlyInBridge do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        auth0: [audience: "my-audience", enabled: true]
+        auth0: [audience: "my-audience", enabled: true],
+        decoder: :atoms
     end
 
     catch_exit(TestBridgeWithAuth0EnabledOnlyInBridge.call("myquery", %{}))

--- a/test/config_validation_test.exs
+++ b/test/config_validation_test.exs
@@ -16,7 +16,7 @@ defmodule BridgeEx.ConfigValidationTest do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
           auth0: [enabled: true],
-          decoder: :atoms
+          decode_keys: :atoms
       end
     end
   end

--- a/test/config_validation_test.exs
+++ b/test/config_validation_test.exs
@@ -15,7 +15,8 @@ defmodule BridgeEx.ConfigValidationTest do
       defmodule TestBridgeWithAuth0EnabledButNoAudience do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          auth0: [enabled: true]
+          auth0: [enabled: true],
+          decoder: :atoms
       end
     end
   end

--- a/test/graphql/client_test.exs
+++ b/test/graphql/client_test.exs
@@ -15,7 +15,7 @@ defmodule BridgeEx.Graphql.ClientTest do
       Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
 
-    assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, :atoms, [])
+    assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, decode_keys: :atoms)
   end
 
   test "call using safer string decoder", %{bypass: bypass} do
@@ -23,7 +23,8 @@ defmodule BridgeEx.Graphql.ClientTest do
       Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
 
-    assert {:ok, %{"result" => "ok"}} = Client.call("localhost:55000/", "", %{}, :strings, [])
+    assert {:ok, %{"result" => "ok"}} =
+             Client.call("localhost:55000/", "", %{}, decode_keys: :strings)
   end
 
   test "call using new enforced atom decoder", %{bypass: bypass} do
@@ -32,6 +33,6 @@ defmodule BridgeEx.Graphql.ClientTest do
     end)
 
     assert {:ok, %{new_atom: "ok"}} =
-             Client.call("localhost:55000/", "", %{}, :existing_atoms, [])
+             Client.call("localhost:55000/", "", %{}, decode_keys: :existing_atoms)
   end
 end

--- a/test/graphql/client_test.exs
+++ b/test/graphql/client_test.exs
@@ -13,15 +13,16 @@ defmodule BridgeEx.Graphql.ClientTest do
 
   test "call using deprecated atom decoder", %{bypass: bypass} do
     Bypass.expect(bypass, "POST", "/", fn conn ->
-      Plug.Conn.resp(conn, 200, Jason.encode!(%{data: %{result: "ok"}}))
+      Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
 
-    assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, [])
+    assert {:ok, %{result: "ok"}} =
+             Client.call("localhost:55000/", "", %{}, &Utils.atom_decoder/1, [])
   end
 
   test "call using safer string decoder", %{bypass: bypass} do
     Bypass.expect(bypass, "POST", "/", fn conn ->
-      Plug.Conn.resp(conn, 200, Jason.encode!(%{data: %{result: "ok"}}))
+      Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
 
     assert {:ok, %{"result" => "ok"}} =
@@ -30,7 +31,7 @@ defmodule BridgeEx.Graphql.ClientTest do
 
   test "call using new enforced atom decoder", %{bypass: bypass} do
     Bypass.expect(bypass, "POST", "/", fn conn ->
-      Plug.Conn.resp(conn, 200, Jason.encode!(%{data: %{"new_atom" => "ok"}}))
+      Plug.Conn.resp(conn, 200, ~s[{"data": {"new_atom": "ok"}}])
     end)
 
     assert {:ok, %{new_atom: "ok"}} =

--- a/test/graphql/client_test.exs
+++ b/test/graphql/client_test.exs
@@ -10,7 +10,7 @@ defmodule BridgeEx.Graphql.ClientTest do
     {:ok, bypass: bypass}
   end
 
-  test "call using deprecated atom decoder", %{bypass: bypass} do
+  test "call using deprecated atom keys decoder", %{bypass: bypass} do
     Bypass.expect(bypass, "POST", "/", fn conn ->
       Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
@@ -18,7 +18,7 @@ defmodule BridgeEx.Graphql.ClientTest do
     assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, decode_keys: :atoms)
   end
 
-  test "call using safer string decoder", %{bypass: bypass} do
+  test "call using safer string keys decoder", %{bypass: bypass} do
     Bypass.expect(bypass, "POST", "/", fn conn ->
       Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
@@ -27,7 +27,7 @@ defmodule BridgeEx.Graphql.ClientTest do
              Client.call("localhost:55000/", "", %{}, decode_keys: :strings)
   end
 
-  test "call using new enforced atom decoder", %{bypass: bypass} do
+  test "call using new existing atom keys decoder", %{bypass: bypass} do
     Bypass.expect(bypass, "POST", "/", fn conn ->
       Plug.Conn.resp(conn, 200, ~s[{"data": {"new_atom": "ok"}}])
     end)

--- a/test/graphql/client_test.exs
+++ b/test/graphql/client_test.exs
@@ -37,4 +37,12 @@ defmodule BridgeEx.Graphql.ClientTest do
     assert {:ok, %{new_atom: "ok"}} =
              Client.call("localhost:55000/", "", %{}, &Utils.existing_atom_decoder/1, [])
   end
+
+  test "call also accepts a atom to be used as the decoder", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
+    end)
+
+    assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, :existing_atoms, [])
+  end
 end

--- a/test/graphql/client_test.exs
+++ b/test/graphql/client_test.exs
@@ -2,7 +2,6 @@ defmodule BridgeEx.Graphql.ClientTest do
   use ExUnit.Case
 
   alias BridgeEx.Graphql.Client
-  alias BridgeEx.Graphql.Utils
 
   alias Bypass
 
@@ -16,8 +15,7 @@ defmodule BridgeEx.Graphql.ClientTest do
       Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
 
-    assert {:ok, %{result: "ok"}} =
-             Client.call("localhost:55000/", "", %{}, &Utils.atom_decoder/1, [])
+    assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, :atoms, [])
   end
 
   test "call using safer string decoder", %{bypass: bypass} do
@@ -25,8 +23,7 @@ defmodule BridgeEx.Graphql.ClientTest do
       Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
     end)
 
-    assert {:ok, %{"result" => "ok"}} =
-             Client.call("localhost:55000/", "", %{}, &Utils.string_decoder/1, [])
+    assert {:ok, %{"result" => "ok"}} = Client.call("localhost:55000/", "", %{}, :strings, [])
   end
 
   test "call using new enforced atom decoder", %{bypass: bypass} do
@@ -35,14 +32,6 @@ defmodule BridgeEx.Graphql.ClientTest do
     end)
 
     assert {:ok, %{new_atom: "ok"}} =
-             Client.call("localhost:55000/", "", %{}, &Utils.existing_atom_decoder/1, [])
-  end
-
-  test "call also accepts a atom to be used as the decoder", %{bypass: bypass} do
-    Bypass.expect(bypass, "POST", "/", fn conn ->
-      Plug.Conn.resp(conn, 200, ~s[{"data": {"result": "ok"}}])
-    end)
-
-    assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, :existing_atoms, [])
+             Client.call("localhost:55000/", "", %{}, :existing_atoms, [])
   end
 end

--- a/test/graphql/client_test.exs
+++ b/test/graphql/client_test.exs
@@ -1,0 +1,39 @@
+defmodule BridgeEx.Graphql.ClientTest do
+  use ExUnit.Case
+
+  alias BridgeEx.Graphql.Client
+  alias BridgeEx.Graphql.Utils
+
+  alias Bypass
+
+  setup do
+    bypass = Bypass.open(port: 55_000)
+    {:ok, bypass: bypass}
+  end
+
+  test "call using deprecated atom decoder", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{data: %{result: "ok"}}))
+    end)
+
+    assert {:ok, %{result: "ok"}} = Client.call("localhost:55000/", "", %{}, [])
+  end
+
+  test "call using safer string decoder", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{data: %{result: "ok"}}))
+    end)
+
+    assert {:ok, %{"result" => "ok"}} =
+             Client.call("localhost:55000/", "", %{}, &Utils.string_decoder/1, [])
+  end
+
+  test "call using new enforced atom decoder", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{data: %{"new_atom" => "ok"}}))
+    end)
+
+    assert {:ok, %{new_atom: "ok"}} =
+             Client.call("localhost:55000/", "", %{}, &Utils.existing_atom_decoder/1, [])
+  end
+end

--- a/test/graphql_test.exs
+++ b/test/graphql_test.exs
@@ -50,7 +50,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestSimpleBridgeStrings do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.string_decoder/1
+        decoder: :strings
     end
 
     assert {:ok, %{"key" => "value"}} = TestSimpleBridgeStrings.call("myquery", %{})
@@ -66,7 +66,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestSimpleBridgeExistingAtoms do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.existing_atom_decoder/1
+        decoder: :existing_atoms
     end
 
     assert {:ok, %{key: "value"}} = TestSimpleBridgeExistingAtoms.call("myquery", %{})

--- a/test/graphql_test.exs
+++ b/test/graphql_test.exs
@@ -21,6 +21,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeDeprecatedOption do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1,
         max_attempts: 2
     end
 
@@ -33,10 +34,42 @@ defmodule BridgeEx.GraphqlTest do
     end)
 
     defmodule TestSimpleBridge do
-      use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+      use BridgeEx.Graphql,
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
     end
 
     assert {:ok, %{key: "value"}} = TestSimpleBridge.call("myquery", %{})
+  end
+
+  test "runs graphql queries over the provided endpoint, decoding as strings", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/graphql", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s[{"data": {"key": "value"}}])
+    end)
+
+    defmodule TestSimpleBridgeStrings do
+      use BridgeEx.Graphql,
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.string_decoder/1
+    end
+
+    assert {:ok, %{"key" => "value"}} = TestSimpleBridgeStrings.call("myquery", %{})
+  end
+
+  test "runs graphql queries over the provided endpoint, decoding as existing atoms", %{
+    bypass: bypass
+  } do
+    Bypass.expect(bypass, "POST", "/graphql", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s[{"data": {"key": "value"}}])
+    end)
+
+    defmodule TestSimpleBridgeExistingAtoms do
+      use BridgeEx.Graphql,
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.existing_atom_decoder/1
+    end
+
+    assert {:ok, %{key: "value"}} = TestSimpleBridgeExistingAtoms.call("myquery", %{})
   end
 
   @tag capture_log: true
@@ -51,7 +84,8 @@ defmodule BridgeEx.GraphqlTest do
 
     defmodule TestBridgeRetriesOnBadResponse do
       use BridgeEx.Graphql,
-        endpoint: "http://localhost:#{bypass.port}/graphql"
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
     end
 
     assert {:ok, %{key: "value"}} =
@@ -73,7 +107,8 @@ defmodule BridgeEx.GraphqlTest do
 
     defmodule TestBridgeRetriesOnError do
       use BridgeEx.Graphql,
-        endpoint: "http://localhost:#{bypass.port}/graphql"
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
     end
 
     assert {:ok, %{key: "value"}} =
@@ -88,7 +123,9 @@ defmodule BridgeEx.GraphqlTest do
     end)
 
     defmodule TestBridgeWithCustomHeaders do
-      use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+      use BridgeEx.Graphql,
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
     end
 
     TestBridgeWithCustomHeaders.call("myquery", %{},
@@ -106,7 +143,9 @@ defmodule BridgeEx.GraphqlTest do
     end)
 
     defmodule TestBridgeForErrors do
-      use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+      use BridgeEx.Graphql,
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
     end
 
     assert {:error,
@@ -136,7 +175,9 @@ defmodule BridgeEx.GraphqlTest do
     end
 
     defmodule TestBridgePreventsRetryWithCustomPolicy do
-      use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+      use BridgeEx.Graphql,
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
     end
 
     assert {:error, {:bad_response, _}} =
@@ -166,7 +207,9 @@ defmodule BridgeEx.GraphqlTest do
     end
 
     defmodule TestBridgeRetriesWithGivenPolicy do
-      use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+      use BridgeEx.Graphql,
+        endpoint: "http://localhost:#{bypass.port}/graphql",
+        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
     end
 
     assert {:ok, %{key: "value"}} =

--- a/test/graphql_test.exs
+++ b/test/graphql_test.exs
@@ -21,7 +21,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeDeprecatedOption do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms,
+        decode_keys: :atoms,
         max_attempts: 2
     end
 
@@ -36,7 +36,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestSimpleBridge do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     assert {:ok, %{key: "value"}} = TestSimpleBridge.call("myquery", %{})
@@ -50,7 +50,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestSimpleBridgeStrings do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :strings
+        decode_keys: :strings
     end
 
     assert {:ok, %{"key" => "value"}} = TestSimpleBridgeStrings.call("myquery", %{})
@@ -66,7 +66,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestSimpleBridgeExistingAtoms do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :existing_atoms
+        decode_keys: :existing_atoms
     end
 
     assert {:ok, %{key: "value"}} = TestSimpleBridgeExistingAtoms.call("myquery", %{})
@@ -85,7 +85,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeRetriesOnBadResponse do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     assert {:ok, %{key: "value"}} =
@@ -108,7 +108,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeRetriesOnError do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     assert {:ok, %{key: "value"}} =
@@ -125,7 +125,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeWithCustomHeaders do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     TestBridgeWithCustomHeaders.call("myquery", %{},
@@ -145,7 +145,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeForErrors do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     assert {:error,
@@ -177,7 +177,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgePreventsRetryWithCustomPolicy do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     assert {:error, {:bad_response, _}} =
@@ -209,7 +209,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeRetriesWithGivenPolicy do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: :atoms
+        decode_keys: :atoms
     end
 
     assert {:ok, %{key: "value"}} =

--- a/test/graphql_test.exs
+++ b/test/graphql_test.exs
@@ -21,7 +21,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeDeprecatedOption do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1,
+        decoder: :atoms,
         max_attempts: 2
     end
 
@@ -36,7 +36,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestSimpleBridge do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
+        decoder: :atoms
     end
 
     assert {:ok, %{key: "value"}} = TestSimpleBridge.call("myquery", %{})
@@ -85,7 +85,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeRetriesOnBadResponse do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
+        decoder: :atoms
     end
 
     assert {:ok, %{key: "value"}} =
@@ -108,7 +108,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeRetriesOnError do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
+        decoder: :atoms
     end
 
     assert {:ok, %{key: "value"}} =
@@ -125,7 +125,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeWithCustomHeaders do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
+        decoder: :atoms
     end
 
     TestBridgeWithCustomHeaders.call("myquery", %{},
@@ -145,7 +145,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeForErrors do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
+        decoder: :atoms
     end
 
     assert {:error,
@@ -177,7 +177,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgePreventsRetryWithCustomPolicy do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
+        decoder: :atoms
     end
 
     assert {:error, {:bad_response, _}} =
@@ -209,7 +209,7 @@ defmodule BridgeEx.GraphqlTest do
     defmodule TestBridgeRetriesWithGivenPolicy do
       use BridgeEx.Graphql,
         endpoint: "http://localhost:#{bypass.port}/graphql",
-        decoder: &BridgeEx.Graphql.Utils.atom_decoder/1
+        decoder: :atoms
     end
 
     assert {:ok, %{key: "value"}} =

--- a/test/log_options_test.exs
+++ b/test/log_options_test.exs
@@ -23,7 +23,7 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestBridgeForErrorsNoLogs do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -48,7 +48,7 @@ defmodule BridgeEx.LogOptionsTest do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
           log_options: [log_query_on_error: true, log_response_on_error: true],
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -74,7 +74,9 @@ defmodule BridgeEx.LogOptionsTest do
       on_exit(fn -> reload_app(_start_prima_auth0_ex? = false) end)
 
       defmodule TestForErrorsAllLogsGlobal do
-        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql", decoder: :atoms
+        use BridgeEx.Graphql,
+          endpoint: "http://localhost:#{bypass.port}/graphql",
+          decode_keys: :atoms
       end
 
       err_log =
@@ -99,7 +101,7 @@ defmodule BridgeEx.LogOptionsTest do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
           log_options: [log_query_on_error: false, log_response_on_error: false],
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -127,7 +129,7 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForErrorsDisabledLogsGlobal do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -151,7 +153,7 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForHTTPErrorNoLogs do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -175,7 +177,7 @@ defmodule BridgeEx.LogOptionsTest do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
           log_options: [log_query_on_error: true],
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -202,7 +204,7 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForHTTPErrorWithLogsGlobal do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -226,7 +228,7 @@ defmodule BridgeEx.LogOptionsTest do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
           log_options: [log_query_on_error: false],
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =
@@ -253,7 +255,7 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForHTTPErrorDisabledLogsGlobal do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          decoder: :atoms
+          decode_keys: :atoms
       end
 
       err_log =

--- a/test/log_options_test.exs
+++ b/test/log_options_test.exs
@@ -21,7 +21,9 @@ defmodule BridgeEx.LogOptionsTest do
       end)
 
       defmodule TestBridgeForErrorsNoLogs do
-        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+        use BridgeEx.Graphql,
+          endpoint: "http://localhost:#{bypass.port}/graphql",
+          decoder: :atoms
       end
 
       err_log =
@@ -45,7 +47,8 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForErrorsAllLogsLocal do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          log_options: [log_query_on_error: true, log_response_on_error: true]
+          log_options: [log_query_on_error: true, log_response_on_error: true],
+          decoder: :atoms
       end
 
       err_log =
@@ -71,7 +74,7 @@ defmodule BridgeEx.LogOptionsTest do
       on_exit(fn -> reload_app(_start_prima_auth0_ex? = false) end)
 
       defmodule TestForErrorsAllLogsGlobal do
-        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql", decoder: :atoms
       end
 
       err_log =
@@ -95,7 +98,8 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForErrorsDisabledLogsLocally do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          log_options: [log_query_on_error: false, log_response_on_error: false]
+          log_options: [log_query_on_error: false, log_response_on_error: false],
+          decoder: :atoms
       end
 
       err_log =
@@ -121,7 +125,9 @@ defmodule BridgeEx.LogOptionsTest do
       on_exit(fn -> reload_app(_start_prima_auth0_ex? = false) end)
 
       defmodule TestForErrorsDisabledLogsGlobal do
-        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+        use BridgeEx.Graphql,
+          endpoint: "http://localhost:#{bypass.port}/graphql",
+          decoder: :atoms
       end
 
       err_log =
@@ -143,7 +149,9 @@ defmodule BridgeEx.LogOptionsTest do
       Bypass.down(bypass)
 
       defmodule TestForHTTPErrorNoLogs do
-        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+        use BridgeEx.Graphql,
+          endpoint: "http://localhost:#{bypass.port}/graphql",
+          decoder: :atoms
       end
 
       err_log =
@@ -166,7 +174,8 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForHTTPErrorWithLogsLocal do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          log_options: [log_query_on_error: true]
+          log_options: [log_query_on_error: true],
+          decoder: :atoms
       end
 
       err_log =
@@ -191,7 +200,9 @@ defmodule BridgeEx.LogOptionsTest do
       on_exit(fn -> reload_app(_start_prima_auth0_ex? = false) end)
 
       defmodule TestForHTTPErrorWithLogsGlobal do
-        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+        use BridgeEx.Graphql,
+          endpoint: "http://localhost:#{bypass.port}/graphql",
+          decoder: :atoms
       end
 
       err_log =
@@ -214,7 +225,8 @@ defmodule BridgeEx.LogOptionsTest do
       defmodule TestForHTTPErrorDisabledLogsLocal do
         use BridgeEx.Graphql,
           endpoint: "http://localhost:#{bypass.port}/graphql",
-          log_options: [log_query_on_error: false]
+          log_options: [log_query_on_error: false],
+          decoder: :atoms
       end
 
       err_log =
@@ -239,7 +251,9 @@ defmodule BridgeEx.LogOptionsTest do
       on_exit(fn -> reload_app(_start_prima_auth0_ex? = false) end)
 
       defmodule TestForHTTPErrorDisabledLogsGlobal do
-        use BridgeEx.Graphql, endpoint: "http://localhost:#{bypass.port}/graphql"
+        use BridgeEx.Graphql,
+          endpoint: "http://localhost:#{bypass.port}/graphql",
+          decoder: :atoms
       end
 
       err_log =


### PR DESCRIPTION
Updated `Client.call` function, which now also accepts a `decoder` (just before options). Decoder is just a function with arity 1 which accepts a body and returns a tuple `{:ok, decoded_body}` or `{:error, any}`. Since the arity of the `call` function has changed, I also created a (deprecated) function with the old arity which fallbacks to atoms keeping the current behavior intact.

Updated the `BridgeEx.Graphql` macro, which now accepts the `decoder` too, and prints a warning when it's not provided (since it falls back to atom decoding).

Also provided three basic decoders in the `Utils` module (to decode keys in `strings`, `atoms` and `existing_atoms`) which simply mirror `Jason` behavior. This approach allows lib users to define their own decode functions which may be useful for some applications.