### PR TITLE
[DEVEX-2946]: GraphQL fragments support in BridgeEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to
 
 ---
 
+## [2.6.0] - 2026-06-16
+
+### Added
+
+- `BridgeEx.Extensions.ExternalResources` now supports an optional `includes` argument to prepend shared files to every resource.
+
+### Changed
+
+- `BridgeEx.Extensions.ExternalResources` can now be used multiple times within the same module. Resources from all invocations are merged and resource names must remain unique.
+
+---
+
+---
+
 ## [2.5.0] - 2026-04-20
 
 ### Added
@@ -233,7 +247,9 @@ and this project adheres to
 
 - Initial implementation of `bridge_ex`
 
-[Unreleased]: https://github.com/primait/bridge_ex/compare/2.4.2...HEAD
+
+[Unreleased]: https://github.com/primait/bridge_ex/compare/2.6.0...HEAD
+[2.6.0]: https://github.com/primait/bridge_ex/compare/2.5.0...2.6.0
 [2.4.2]: https://github.com/primait/bridge_ex/compare/2.4.1...2.4.2
 [2.4.1]: https://github.com/primait/bridge_ex/compare/2.4.0-rc.0...2.4.1
 [2.4.0]: https://github.com/primait/bridge_ex/compare/2.3.0...2.4.0

--- a/README.md
+++ b/README.md
@@ -40,16 +40,57 @@ Refer to [the documentation](https://hexdocs.pm/bridge_ex/BridgeEx.Graphql.html)
 
 If you need more control on your requests you can use [`BridgeEx.Graphql.Client.call`](https://hexdocs.pm/bridge_ex/BridgeEx.Graphql.Client.html#call/7) directly.
 
-The library supports preloading queries from external files via the `BridgeEx.Extensions.ExternalResources` optional macro:
+### Loading queries from external files
+
+The library supports preloading queries from external files via the optional `BridgeEx.Extensions.ExternalResources` macro:
 
 ```elixir
 defmodule MyApp.SomeServiceBridge do
-  use BridgeEx.Graphql, endpoint: "http://some_service.example.com", decode_keys: :strings
-  use BridgeEx.Extensions.ExternalResources, resources: [my_query: "my_query.graphql"]
+  use BridgeEx.Graphql,
+    endpoint: "http://some_service.example.com",
+    decode_keys: :strings
+
+  use BridgeEx.Extensions.ExternalResources,
+    resources: [
+      my_query: "my_query.graphql"
+    ]
 
   def my_query(%{} = variables), do: call(my_query(), variables)
 end
 ```
+
+The `resources` option is required and maps resource names to files. Each file path is resolved relative to the module source file.
+
+If you need to prepend shared content to multiple resources, you can use the optional `includes` option:
+
+```elixir
+use BridgeEx.Extensions.ExternalResources,
+  resources: [
+    get_user: "queries/get_user.graphql",
+    get_policy: "queries/get_policy.graphql"
+  ],
+  includes: [
+    "queries/fragments.graphql"
+  ]
+```
+
+Included files are concatenated, in order, and prepended to every resource.
+
+You can invoke `BridgeEx.Extensions.ExternalResources` multiple times within the same module. Resources from all invocations are merged, allowing different resources to use different include sets:
+
+```elixir
+defmodule MyApp.SomeServiceBridge do
+  use BridgeEx.Extensions.ExternalResources,
+    resources: [get_user: "queries/get_user.graphql"],
+    includes: ["queries/user_fragments.graphql"]
+
+  use BridgeEx.Extensions.ExternalResources,
+    resources: [get_policy: "queries/get_policy.graphql"],
+    includes: ["queries/policy_fragments.graphql"]
+end
+```
+
+Resource names must be unique across all invocations.
 
 ### Runtime options
 

--- a/lib/extensions/external_resources.ex
+++ b/lib/extensions/external_resources.ex
@@ -38,18 +38,24 @@ defmodule BridgeEx.Extensions.ExternalResources do
   end
   ```
   """
-
   defmacro __using__(opts) do
-    {resources, opts} = Keyword.pop(opts, :resources)
+    {resources_opt, opts} = Keyword.pop(opts, :resources)
 
-    if not is_list(resources) do
+    if not is_list(resources_opt) do
       raise ArgumentError,
             """
-            resources argument in "use #{__MODULE__}" is mandatory and must be a list, got: #{inspect(opts)}
+            resources argument in "use #{__MODULE__}" is mandatory and must be a list, got: #{inspect(resources_opt)}
             """
     end
 
-    {includes, opts} = Keyword.pop(opts, :includes, [])
+    {includes_opt, opts} = Keyword.pop(opts, :includes, [])
+
+    if not is_list(includes_opt) do
+      raise ArgumentError,
+            """
+            includes argument in "use #{__MODULE__}" must be a list, got: #{inspect(includes_opt)}
+            """
+    end
 
     if not Enum.empty?(opts) do
       raise ArgumentError,
@@ -58,39 +64,75 @@ defmodule BridgeEx.Extensions.ExternalResources do
             """
     end
 
-    dir = Path.dirname(__CALLER__.file)
+    if is_nil(__CALLER__.module) do
+      raise ArgumentError,
+            """
+            "use #{__MODULE__}" must be called inside a module
+            """
+    end
 
-    included_contents =
-      for path <- includes, into: "" do
-        content = dir |> Path.join(path) |> File.read!()
+    includes_section = Enum.map_join(includes_opt, "\n", &read_ext_res!(__CALLER__, &1))
 
-        "#{content}\n"
+    resources =
+      Enum.map(resources_opt, fn {name, path} ->
+        content = read_ext_res!(__CALLER__, path)
+
+        if includes_section == "" do
+          {name, content}
+        else
+          {name, "#{includes_section}\n#{content}"}
+        end
+      end)
+
+    quote bind_quoted: [resources: resources, callback: __MODULE__] do
+      if not Module.has_attribute?(__MODULE__, :bridge_ex_external_resources) do
+        Module.register_attribute(__MODULE__, :bridge_ex_external_resources, accumulate: true)
+        Module.put_attribute(__MODULE__, :before_compile, callback)
       end
 
-    resources_contents =
-      for {name, path} <- resources, into: %{} do
-        content = dir |> Path.join(path) |> File.read!()
+      Module.put_attribute(__MODULE__, :bridge_ex_external_resources, resources)
+    end
+  end
 
-        {name, included_contents <> content}
-      end
+  defmacro __before_compile__(%Macro.Env{} = env) do
+    resources_list =
+      env.module
+      |> Module.get_attribute(:bridge_ex_external_resources, [])
+      |> List.flatten()
+
+    resources_map =
+      Enum.reduce(resources_list, %{}, fn {name, content}, map ->
+        if Map.has_key?(map, name) do
+          raise ArgumentError, """
+          resource names must be unique in "use #{__MODULE__}", got duplicate: #{inspect(name)}
+          """
+        end
+
+        Map.put(map, name, content)
+      end)
 
     getters =
-      for {name, _path} <- resources do
+      for {name, _content} <- resources_map do
         quote do
           @spec unquote(name)() :: String.t()
           def unquote(name)(), do: Map.fetch!(external_resources(), unquote(name))
         end
       end
 
-    external_resource_attributes =
-      for {_name, path} <- resources do
-        quote do: @external_resource(unquote(path))
-      end
-
     quote generated: true do
-      unquote_splicing(external_resource_attributes)
+      @spec external_resources :: %{atom => String.t()}
+      defp external_resources, do: unquote(Macro.escape(resources_map))
+
       unquote_splicing(getters)
-      defp external_resources, do: unquote(Macro.escape(resources_contents))
     end
+  end
+
+  @spec read_ext_res!(Macro.Env.t(), rel_path :: Path.t()) :: binary
+  defp read_ext_res!(%Macro.Env{file: file, module: module}, rel_path) do
+    path = file |> Path.dirname() |> Path.join(rel_path)
+    content = File.read!(path)
+    Module.put_attribute(module, :external_resource, path)
+
+    content
   end
 end

--- a/lib/extensions/external_resources.ex
+++ b/lib/extensions/external_resources.ex
@@ -6,6 +6,8 @@ defmodule BridgeEx.Extensions.ExternalResources do
 
     * `resources` (required): enumerable of resource names (atoms) and their paths (strings).
       Each path is assumed to be relative to the module directory.
+    * `includes` (optional): enumerable of paths (strings) to files that should be prepended to every resource.
+      Each path is assumed to be relative to the module directory.
 
   ## Examples
 
@@ -37,10 +39,40 @@ defmodule BridgeEx.Extensions.ExternalResources do
   ```
   """
 
-  defmacro __using__(resources: resources) do
+  defmacro __using__(opts) do
+    {resources, opts} = Keyword.pop(opts, :resources)
+
+    if not is_list(resources) do
+      raise ArgumentError,
+            """
+            resources argument in "use #{__MODULE__}" is mandatory and must be a list, got: #{inspect(opts)}
+            """
+    end
+
+    {includes, opts} = Keyword.pop(opts, :includes, [])
+
+    if not Enum.empty?(opts) do
+      raise ArgumentError,
+            """
+            got unexpected argument in "use #{__MODULE__}": #{inspect(opts)}
+            """
+    end
+
     dir = Path.dirname(__CALLER__.file)
-    resources = for {name, path} <- resources, do: {name, Path.join(dir, path)}
-    contents = for {name, path} <- resources, into: %{}, do: {name, File.read!(path)}
+
+    included_contents =
+      for path <- includes, into: "" do
+        content = dir |> Path.join(path) |> File.read!()
+
+        "#{content}\n"
+      end
+
+    resources_contents =
+      for {name, path} <- resources, into: %{} do
+        content = dir |> Path.join(path) |> File.read!()
+
+        {name, included_contents <> content}
+      end
 
     getters =
       for {name, _path} <- resources do
@@ -58,7 +90,7 @@ defmodule BridgeEx.Extensions.ExternalResources do
     quote generated: true do
       unquote_splicing(external_resource_attributes)
       unquote_splicing(getters)
-      defp external_resources, do: unquote(Macro.escape(contents))
+      defp external_resources, do: unquote(Macro.escape(resources_contents))
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BridgeEx.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/bridge_ex"
-  @version "2.5.0"
+  @version "2.6.0"
 
   def project do
     [

--- a/test/extensions/external_resources_test.exs
+++ b/test/extensions/external_resources_test.exs
@@ -29,7 +29,7 @@ defmodule BridgeEx.Extensions.ExternalResourcesTest do
         use BridgeEx.Extensions.ExternalResources
       end
 
-    assert_raise FunctionClauseError, fn -> Code.eval_quoted(quoted) end
+    assert_raise ArgumentError, fn -> Code.eval_quoted(quoted) end
   end
 
   test "it fails to compile if a file is missing" do

--- a/test/extensions/external_resources_test.exs
+++ b/test/extensions/external_resources_test.exs
@@ -14,19 +14,52 @@ defmodule BridgeEx.Extensions.ExternalResourcesTest do
     assert "42" == Example.answer()
   end
 
-  test "it marks files as external resources" do
-    paths =
-      for {:external_resource, [path]} <- Example.__info__(:attributes),
-          into: MapSet.new(),
-          do: Path.relative_to(path, __DIR__)
+  defmodule ExampleWithIncludes do
+    use BridgeEx.Extensions.ExternalResources,
+      resources: [
+        question: "resources/question.txt",
+        answer: "resources/answer.txt"
+      ],
+      includes: ["resources/header.txt", "resources/extra.txt"]
+  end
 
-    assert MapSet.new(["resources/question.txt", "resources/answer.txt"]) == paths
+  test "it prepends included files" do
+    assert "header content\nextra content\nHow many roads must a man walk down?" ==
+             ExampleWithIncludes.question()
+  end
+
+  test "it fails to compile if an include file is missing" do
+    quoted =
+      quote do
+        defmodule MissingInclude do
+          use BridgeEx.Extensions.ExternalResources,
+            resources: [question: "resources/question.txt"],
+            includes: ["resources/non_existent.txt"]
+        end
+      end
+
+    assert_raise File.Error, fn -> Code.eval_quoted(quoted) end
+  end
+
+  test "it fails to compile if includes is not a list" do
+    quoted =
+      quote do
+        defmodule BadIncludes do
+          use BridgeEx.Extensions.ExternalResources,
+            resources: [question: "resources/question.txt"],
+            includes: :bad_includes
+        end
+      end
+
+    assert_raise ArgumentError, fn -> Code.eval_quoted(quoted) end
   end
 
   test "it fails to compile if no resources are given" do
     quoted =
       quote do
-        use BridgeEx.Extensions.ExternalResources
+        defmodule NoResources do
+          use BridgeEx.Extensions.ExternalResources
+        end
       end
 
     assert_raise ArgumentError, fn -> Code.eval_quoted(quoted) end
@@ -35,12 +68,58 @@ defmodule BridgeEx.Extensions.ExternalResourcesTest do
   test "it fails to compile if a file is missing" do
     quoted =
       quote do
-        use BridgeEx.Extensions.ExternalResources,
-          resources: [
-            missing: "missing.txt"
-          ]
+        defmodule MissingFile do
+          use BridgeEx.Extensions.ExternalResources,
+            resources: [missing: "missing.txt"]
+        end
       end
 
     assert_raise File.Error, fn -> Code.eval_quoted(quoted) end
+  end
+
+  test "it fails to compile if resources is not a list" do
+    quoted =
+      quote do
+        defmodule BadResources do
+          use BridgeEx.Extensions.ExternalResources,
+            resources: :bad_res
+        end
+      end
+
+    assert_raise ArgumentError, fn -> Code.eval_quoted(quoted) end
+  end
+
+  test "it fails to compile when an unknown option is passed" do
+    quoted =
+      quote do
+        defmodule BadOpt do
+          use BridgeEx.Extensions.ExternalResources,
+            bad_opt: []
+        end
+      end
+
+    assert_raise ArgumentError, fn -> Code.eval_quoted(quoted) end
+  end
+
+  test "it fails to compile if resources contains a bad entry" do
+    quoted =
+      quote do
+        defmodule BadEntry do
+          use BridgeEx.Extensions.ExternalResources,
+            resources: [:bad_entry]
+        end
+      end
+
+    assert_raise FunctionClauseError, fn -> Code.eval_quoted(quoted) end
+  end
+
+  test "it fails to compile if not called inside a module" do
+    quoted =
+      quote do
+        use BridgeEx.Extensions.ExternalResources,
+          resources: [question: "resources/question.txt"]
+      end
+
+    assert_raise ArgumentError, fn -> Code.eval_quoted(quoted) end
   end
 end

--- a/test/extensions/resources/extra.txt
+++ b/test/extensions/resources/extra.txt
@@ -1,0 +1,1 @@
+extra content

--- a/test/extensions/resources/header.txt
+++ b/test/extensions/resources/header.txt
@@ -1,0 +1,1 @@
+header content


### PR DESCRIPTION
1. added the `includes` option to `use BridgeEx.Extensions.ExternalResources`, this allows users to move fragment or shared resources to separate files
2. now multiple `use BridgeEx.Extensions.ExternalResources` are allowed in the same module, this allows to add only relevant `includes` to a group of resources without polluting others