### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml.njk
+++ b/catalog-info.yaml.njk
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bridge_ex
+  description: sadasd
+tags:
+- elixir
+- python
+spec:
+  type: library
+  lifecycle: experimental
+  owner: group:default/org-prima
+  system: prima.it


### PR DESCRIPTION
** Depo PR to test `add-component-to-catalog` [software template](https://github.com/primait/prima-backstage/pull/1206). Do not review **

This PR adds a Backstage Component entity definition.

Generated by the `add-component-to-catalog` software template.


