### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml.njk
+++ b/catalog-info.yaml.njk
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bridge_ex
+  description: sadasd
+tags:
+- rust
+spec:
+  type: library
+  lifecycle: experimental
+  owner: group:default/org-prima
+  system: prima.it


### PR DESCRIPTION
This PR adds a Backstage Component entity definition.

Generated by the `add-component-to-catalog` software template.
